### PR TITLE
Fix showAllCategories to reveal hidden categories

### DIFF
--- a/public/renderer.js
+++ b/public/renderer.js
@@ -604,11 +604,10 @@ function filterCategories(partialCategory) {
 }
 
 function showAllCategories() {
-  const navElements = document.getElementsByClassName(
-    "nav-element:not(.hidden)"
-  );
-
-  Array.from(navElements).forEach((nav) => { nav.classList.remove("hidden"); });
+  const navElements = document.querySelectorAll('.nav-element.hidden');
+  navElements.forEach((nav) => {
+    nav.classList.remove('hidden');
+  });
   selectNav(-currentCategory);
 }
 


### PR DESCRIPTION
## Summary
- use `querySelectorAll` in `showAllCategories` to select hidden nav elements
- remove `hidden` class from each element before resetting navigation

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685cdacfdc908323a1c9be75b7775de3