### PR TITLE
Fix variable declarations in renderer

### DIFF
--- a/public/renderer.js
+++ b/public/renderer.js
@@ -14,6 +14,8 @@ let pomodoroTimerId = null;
 let timeLeftInSeconds = 0;
 let isTimerPaused = false;
 let pomodoroCategory = null;
+let content;
+let subcategories;
 
 document.addEventListener("DOMContentLoaded", () => {
   textbox = document.getElementById("textbox");


### PR DESCRIPTION
## Summary
- declare `content` and `subcategories` in `public/renderer.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cdad116c08323a740e35b9cdce047