### PR TITLE
Improve log rendering security

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ ipcMain.on("commit-color-to-config", (event, colorId) => {
   config.color = colorId;
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
   accentColor = colorId;
-  win.webContents.executeJavaScript(`setTheme('${accentColor}', '${themeColor}')`);
+  win.webContents.send('apply-theme', { accentColor, themeColor });
 });
 
 ipcMain.on("commit-theme-to-config", (event, themeId) => {
@@ -261,7 +261,7 @@ ipcMain.on("commit-theme-to-config", (event, themeId) => {
   config.theme = themeId;
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
   themeColor = themeId;
-  win.webContents.executeJavaScript(`setTheme('${accentColor}', '${themeColor}')`);
+  win.webContents.send('apply-theme', { accentColor, themeColor });
 });
 
 ipcMain.on("open-file-dialog", async (event) => {
@@ -336,8 +336,17 @@ function serveLogs() {
       console.error("Error reading the file:", err);
       return;
     }
-    win.webContents.executeJavaScript(`setTheme('${accentColor}', '${themeColor}')`);
-    win.webContents.executeJavaScript(`renderLogs(${data})`);
+
+    let logs;
+    try {
+      logs = JSON.parse(data);
+    } catch (parseErr) {
+      logs = {};
+      console.error("Error parsing logs:", parseErr);
+    }
+
+    win.webContents.send('apply-theme', { accentColor, themeColor });
+    win.webContents.send('logs-data', logs);
   });
 }
 

--- a/preload.js
+++ b/preload.js
@@ -10,4 +10,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     emptyCategory: (category) => ipcRenderer.send('modify-category-empty', category),
     moveCategory: (content, number) => ipcRenderer.send('modify-category-move', content, number),
     requestHide: () => ipcRenderer.send('request-hide'),
+    onApplyTheme: (callback) => ipcRenderer.on('apply-theme', (event, data) => callback(data.accentColor, data.themeColor)),
+    onLogsData: (callback) => ipcRenderer.on('logs-data', (event, logs) => callback(logs)),
 });

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -18,6 +18,12 @@ let pomodoroCategory = null;
 document.addEventListener("DOMContentLoaded", () => {
   textbox = document.getElementById("textbox");
   window.electronAPI.refreshLogs();
+  window.electronAPI.onApplyTheme((accent, theme) => {
+    setTheme(accent, theme);
+  });
+  window.electronAPI.onLogsData((logs) => {
+    renderLogs(logs);
+  });
   initialiseForm();
   hideSubcategories();
 });


### PR DESCRIPTION
## Summary
- remove direct string interpolation from `executeJavaScript`
- send theme and log data via IPC events
- listen for the new events in the renderer

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cdad282d88323944f542489b67a97