### PR TITLE
Expose removeCategoryElements globally

### DIFF
--- a/public/renderer.js
+++ b/public/renderer.js
@@ -321,6 +321,17 @@ function displayError(err, duration) {
   setTimeout(() => { errorMessage.style.display = "none"; }, duration);
 }
 
+function removeCategoryElements(categoryName) {
+  const categoryPattern = new RegExp(
+    `^category-(nav|logs)-${categoryName}(:|$)`
+  );
+  document.querySelectorAll("[id]").forEach((element) => {
+    if (categoryPattern.test(element.id)) {
+      element.remove();
+    }
+  });
+}
+
 function initialiseForm() {
   const textForm = document.getElementById("text-form");
   const errorMessage = document.getElementById("error-message");
@@ -475,17 +486,6 @@ function initialiseForm() {
     }
     setTimeout(() => { selectNav(0); }, 5);
   });
-
-  function removeCategoryElements(categoryName) {
-    const categoryPattern = new RegExp(
-      `^category-(nav|logs)-${categoryName}(:|$)`
-    );
-    document.querySelectorAll("[id]").forEach((element) => {
-      if (categoryPattern.test(element.id)) {
-        element.remove();
-      }
-    });
-  }
 
   textbox.addEventListener("input", function () {
     const inputValue = this.value.trim();


### PR DESCRIPTION
## Summary
- move `removeCategoryElements` above `initialiseForm`
- keep behaviour by updating its placement in `renderer.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cdd1bd1688323a467ed57c490bfcf