### PR TITLE
Fix /m command error handling

### DIFF
--- a/public/renderer.js
+++ b/public/renderer.js
@@ -439,7 +439,7 @@ function initialiseForm() {
           window.electronAPI.moveCategory(category, number);
           window.electronAPI.refreshLogs();
         } else {
-          console.log("No valid number found after '/m'");
+          displayError("No valid number found after '/m'.", 4000);
         }
       } else if (content.startsWith("pom:")) {
         if (!categoryExists) {


### PR DESCRIPTION
## Summary
- remove leftover debug logging for `/m` command
- show an error when `/m` is missing a number

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685cdd19e3108323be11b5e608f89417