### PR TITLE
Refactor log update handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,6 +341,20 @@ function serveLogs() {
   });
 }
 
+function updateLogs(modifierFn, callback) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) throw err;
+
+    let json = JSON.parse(data);
+    modifierFn(json);
+
+    fs.writeFile(filePath, JSON.stringify(json, null, 2), (err) => {
+      if (err) throw err;
+      if (callback) callback();
+    });
+  });
+}
+
 ipcMain.on("refresh-logs", (event) => {
   serveLogs();
 });
@@ -439,11 +453,7 @@ ipcMain.on("text-submitted", (event, formData) => {
 });
 
 ipcMain.on("modify-log-edit", (event, logDataArray) => {
-  fs.readFile(filePath, (err, data) => {
-    if (err) throw err;
-
-    let json = JSON.parse(data);
-
+  updateLogs((json) => {
     logDataArray.forEach((logData) => {
       let categoryObj = json.categories.find(
         (cat) => cat.name === logData.category
@@ -457,19 +467,11 @@ ipcMain.on("modify-log-edit", (event, logDataArray) => {
         }
       }
     });
-
-    fs.writeFile(filePath, JSON.stringify(json, null, 2), (err) => {
-      if (err) throw err;
-    });
-  });
+  }, serveLogs);
 });
 
 ipcMain.on("modify-log-delete", (event, logDataArray) => {
-  fs.readFile(filePath, (err, data) => {
-    if (err) throw err;
-
-    let json = JSON.parse(data);
-
+  updateLogs((json) => {
     logDataArray.forEach((logData) => {
       let categoryObj = json.categories.find(
         (cat) => cat.name === logData.logCategory
@@ -483,19 +485,11 @@ ipcMain.on("modify-log-delete", (event, logDataArray) => {
         }
       }
     });
-
-    fs.writeFile(filePath, JSON.stringify(json, null, 2), (err) => {
-      if (err) throw err;
-    });
-  });
+  }, serveLogs);
 });
 
 ipcMain.on("modify-log-done", (event, logDataArray) => {
-  fs.readFile(filePath, (err, data) => {
-    if (err) throw err;
-
-    let json = JSON.parse(data);
-
+  updateLogs((json) => {
     logDataArray.forEach((logData) => {
       let categoryObj = json.categories.find(
         (cat) => cat.name === logData.logCategory
@@ -509,38 +503,21 @@ ipcMain.on("modify-log-done", (event, logDataArray) => {
         }
       }
     });
-
-    fs.writeFile(filePath, JSON.stringify(json, null, 2), (err) => {
-      if (err) throw err;
-    });
-  });
+  }, serveLogs);
 });
 
 ipcMain.on("modify-category-delete", (event, categoryName) => {
-  fs.readFile(filePath, (err, data) => {
-    if (err) throw err;
-
-    let json = JSON.parse(data);
-
+  updateLogs((json) => {
     json.categories.forEach(cat => {
       if (cat.name === categoryName || cat.name.startsWith(categoryName + ':')) {
         cat.status = "deleted";
       }
     });
-
-    fs.writeFile(filePath, JSON.stringify(json, null, 2), (err) => {
-      if (err) throw err;
-      serveLogs();
-    });
-  });
+  }, serveLogs);
 });
 
 ipcMain.on("modify-category-empty", (event, categoryName) => {
-  fs.readFile(filePath, (err, data) => {
-    if (err) throw err;
-
-    let json = JSON.parse(data);
-
+  updateLogs((json) => {
     let categoryObj = json.categories.find((cat) => cat.name === categoryName);
 
     if (categoryObj) {
@@ -548,20 +525,11 @@ ipcMain.on("modify-category-empty", (event, categoryName) => {
         log.status = "deleted";
       });
     }
-
-    fs.writeFile(filePath, JSON.stringify(json, null, 2), (err) => {
-      if (err) throw err;
-      serveLogs();
-    });
-  });
+  }, serveLogs);
 });
 
 ipcMain.on("modify-category-move", (event, categoryName, position) => {
-  fs.readFile(filePath, (err, data) => {
-    if (err) throw err;
-
-    let json = JSON.parse(data);
-
+  updateLogs((json) => {
     const categoryIndex = json.categories.findIndex(
       (cat) => cat.name === categoryName
     );
@@ -570,15 +538,8 @@ ipcMain.on("modify-category-move", (event, categoryName, position) => {
       const [categoryObj] = json.categories.splice(categoryIndex, 1);
       position = Math.max(0, Math.min(position, json.categories.length));
       json.categories.splice(position, 0, categoryObj);
-
-      fs.writeFile(filePath, JSON.stringify(json, null, 2), (err) => {
-        if (err) throw err;
-        serveLogs();
-      });
-    } else {
-      serveLogs();
     }
-  });
+  }, serveLogs);
 });
 
 app.on("will-quit", () => {


### PR DESCRIPTION
## Summary
- add helper `updateLogs` to read-modify-write `captainsLogs.json`
- refactor IPC handlers to use the new helper
- refresh UI after updating log or category data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cdd159bd88323aeac63a1dee6997c